### PR TITLE
Update control search and add feature tests

### DIFF
--- a/app/Http/Controllers/FormularioController.php
+++ b/app/Http/Controllers/FormularioController.php
@@ -23,7 +23,7 @@ class FormularioController extends Controller
         if ($request->filled('search')) {
             $query->where(function($q) use ($search) {
                 $q->where('Nombre', 'like', '%' . $search . '%')
-                  ->orWhere('numero_control', 'like', '%' . $search . '%')
+                  ->orWhere('control', 'like', '%' . $search . '%')
                   ->orWhere('CURP', 'like', '%' . $search . '%')
                   ->orWhere('email', 'like', '%' . $search . '%')
                   ->orWhere('especialidad', 'like', '%' . $search . '%')

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 }

--- a/tests/Feature/FormularioSearchTest.php
+++ b/tests/Feature/FormularioSearchTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Formulario;
+use App\Models\Alumno;
+use Spatie\Permission\Models\Role;
+
+class FormularioSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_search_by_control_returns_record(): void
+    {
+        Role::create(['name' => 'alumno', 'guard_name' => 'alumno']);
+
+        $this->withoutVite();
+
+        $alumno = Alumno::create([
+            'numero_control' => 'A001',
+            'CURP' => 'TESTCURP123456789',
+            'especialidad' => 'Informatica',
+            'semestre' => '1',
+            'Grupo' => 'A',
+            'Nombre' => 'Test Alumno',
+            'email' => 'alumno@example.com',
+            'estatus' => 'activo',
+        ]);
+
+        $formulario = Formulario::create([
+            'alumno_id' => $alumno->id,
+            'nombre' => 'Test Alumno',
+            'control' => 'C001',
+            'especialidad' => 'Informatica',
+            'grupo' => 'A',
+            'semestre' => '1',
+            'fecha' => now()->toDateString(),
+            'curp' => 'TESTCURP123456789',
+        ]);
+
+        $this->actingAs($alumno, 'alumno');
+
+        $response = $this->get('/formularios?search=' . $formulario->control);
+
+        $response->assertStatus(200);
+        $response->assertViewHas('formularios', function ($formularios) use ($formulario) {
+            return $formularios->contains($formulario);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- search by `control` instead of `numero_control`
- run feature tests with sqlite memory database
- adjust existing example test to match redirect behavior
- add Formulario search feature test

## Testing
- `vendor/bin/phpunit --testsuite Feature`

------
https://chatgpt.com/codex/tasks/task_b_6851702deb548330b263678317ede5d1