### PR TITLE
Fix tipo_pago filtering in financial services view

### DIFF
--- a/app/Http/Controllers/GestionEController.php
+++ b/app/Http/Controllers/GestionEController.php
@@ -114,6 +114,7 @@ class GestionEController extends Controller
         $search = $request->input('buscar');
         $especialidad = $request->input('especialidad');
         $grupo = $request->input('grupo');
+        $tipo_pago = $request->input('tipo_pago');
         
         // Construir la consulta con los filtros
         $query = FormularioE::query();
@@ -140,14 +141,19 @@ class GestionEController extends Controller
             $query->where('grupo', $grupo);
         }
 
+        if ($tipo_pago) {
+            $query->where('tipo_pago', $tipo_pago);
+        }
+
         $formularios = $query->paginate(10);
 
         // Obtener las listas para los filtros
         $controles = FormularioE::distinct()->pluck('numero_control');
         $especialidades = FormularioE::distinct()->pluck('especialidad');
         $grupos = FormularioE::distinct()->pluck('grupo');
-        
-        return view('financiero_user.SolicitudesServiciosS', compact('formularios', 'controles', 'especialidades', 'grupos'));
+        $tipo_pagos = FormularioE::distinct()->pluck('tipo_pago');
+
+        return view('financiero_user.SolicitudesServiciosS', compact('formularios', 'controles', 'especialidades', 'grupos', 'tipo_pagos'));
     }
 
     public function indexComprobantes($id)

--- a/resources/views/financiero_user/SolicitudesServiciosS.blade.php
+++ b/resources/views/financiero_user/SolicitudesServiciosS.blade.php
@@ -66,6 +66,15 @@
                                     </select>
                                 </div>
                                 <div class="me-2">
+                                    <label class="form-label">Tipo de Pago</label>
+                                    <select class="form-select form-select-sm" id="tipo_pago" name="tipo_pago">
+                                        <option value="">Todos</option>
+                                        @foreach ($tipo_pagos as $tipo)
+                                            <option value="{{ $tipo }}">{{ $tipo }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="me-2">
                                     <label class="form-label">Buscar</label>
                                     <input type="text" class="form-control form-control-sm" name="buscar" value="{{ request('buscar') }}" aria-label="Buscar">
                                 </div>


### PR DESCRIPTION
## Summary
- support filtering by `tipo_pago` in `GestionEController`
- expose available `tipo_pagos` in `SolicitudesServiciosS` view

## Testing
- `npm test` *(fails: Missing script)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516db7bf0883309ff1283cd96ddaf4